### PR TITLE
add VAT-rate for Saint Barthelemy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ According to https://semver.org/#spec-item-4 0.x versions should not be consider
 
 ## [Unreleased]
 
+## [0.2.4] - 2019-05-31
+
+### Added
+
+- VAT for Saint Barthélemy
+
 ## [0.2.3] - 2019-05-29
 
 ### Added

--- a/lib/db/vat_rates.csv
+++ b/lib/db/vat_rates.csv
@@ -25,6 +25,7 @@ BG,Bulgaria,20,0000-01-01
 BH,Bahrain,0,0000-01-01
 BI,Burundi,18,0000-01-01
 BJ,Benin,18,0000-01-01
+BL,Saint Barthelemy,0,0000-01-01
 BM,Bermuda,0,0000-01-01
 BN,Brunei,0,0000-01-01
 BO,Bolivia,13,0000-01-01

--- a/lib/vat_rate/version.rb
+++ b/lib/vat_rate/version.rb
@@ -1,3 +1,3 @@
 module VatRate
-  VERSION = '0.2.3'.freeze
+  VERSION = '0.2.4'.freeze
 end


### PR DESCRIPTION
Checklist:

- [x] Make sure your code is simple and clear
- [x] Increment version
- [x] Update [readme](README.md)
- [x] Update [changelog](CHANGELOG.md). [Best practices](https://keepachangelog.com/en/1.0.0/)

Changes:
- Add a 0 VAT-rate to Saint Barthelemy.