### PR TITLE
Add vat rates for Tokelau and French Southern Territories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ According to https://semver.org/#spec-item-4 0.x versions should not be consider
 
 ## [Unreleased]
 
+## [0.2.6] - 2019-06-05
+
+### Added
+
+- VAT for French Southern Territories and Tokelau
+
 ## [0.2.5] - 2019-06-03
 
 ### Added

--- a/lib/db/vat_rates.csv
+++ b/lib/db/vat_rates.csv
@@ -215,9 +215,11 @@ SY,Syria,0,0000-01-01
 SZ,Swaziland,0,0000-01-01
 TC,Turks and Caicos Islands,0,0000-01-01
 TD,Chad,18,0000-01-01
+TF,French Southern Territories,19.6,0000-01-01
 TG,Togo,18,0000-01-01
 TH,Thailand,10,0000-01-01
 TJ,Tajikistan,20,0000-01-01
+TK,Tokelau,12.5,0000-01-01
 TL,Timor Leste,0,0000-01-01
 TM,Turkmenistan,15,0000-01-01
 TN,Tunisia,18,0000-01-01

--- a/lib/vat_rate/version.rb
+++ b/lib/vat_rate/version.rb
@@ -1,3 +1,3 @@
 module VatRate
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.6'.freeze
 end


### PR DESCRIPTION
Добавил ставки для Tokelau и French Southern Territories, данные предоставлены юр отделом.